### PR TITLE
Avoid JSON.parse on missing subscription cache entries

### DIFF
--- a/nl.upstart-it.com.feedbin/plugin.js
+++ b/nl.upstart-it.com.feedbin/plugin.js
@@ -198,9 +198,22 @@ function processNewItem(feedItem, starredEntries = [], unreadEntries = []) {
   }
 
   // Feed Information + Icon
-  const subscriptionInformation = JSON.parse(
-    getItem(`feed-${feedItem.feed_id}`)
-  );
+  const subscriptionRaw = getItem(`feed-${feedItem.feed_id}`);
+  let subscriptionInformation = null;
+
+  // Avoid JSON.parse on undefined / "undefined" / empty
+  if (subscriptionRaw && subscriptionRaw !== "undefined") {
+    try {
+      subscriptionInformation = JSON.parse(subscriptionRaw);
+    } catch (e) {
+      console.error(
+        "Failed to parse subscription info for feed",
+        feedItem.feed_id,
+        e
+      );
+      subscriptionInformation = null;
+    }
+  }
 
   if (subscriptionInformation?.title) {
     let annotation = Annotation.createWithText(subscriptionInformation.title);


### PR DESCRIPTION
This fixes a JSON parse error in the Feedbin plugin.

When there is no cached subscription info for a feed, getItem("feed-<id>") can return "undefined" or undefined. The plugin then calls JSON.parse on that value, which throws SyntaxError: JSON Parse error: Unexpected identifier "undefined" in Tapestry Loom and prevents items from loading.

This change:

- Reads the cached value into subscriptionRaw.
- Only calls JSON.parse if the value is truthy and not "undefined".
- Catches any parsing errors and logs them instead of throwing.

Tested in Tapestry Loom with a Feedbin account that previously triggered the error.

Fixes #2